### PR TITLE
Only import google-client-api, not all Google APIs

### DIFF
--- a/google-calendar.html
+++ b/google-calendar.html
@@ -1,6 +1,6 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../google-signin/google-signin.html">
-<link rel="import" href="../google-apis/google-apis.html">
+<link rel="import" href="../google-apis/google-client-api.html">
 
 <!--
 Element loading Google Calendar API.


### PR DESCRIPTION
@devnook: This should reduce the number of imports, after the google-apis refactoring :)
