### PR TITLE
Elements attributes should contain dashes rather than being in camelCase

### DIFF
--- a/google-calendar.html
+++ b/google-calendar.html
@@ -167,10 +167,10 @@ A badge showing the free/busy status based on the events in a given calendar.
 ##### Example
 
     <google-calendar-busy-now
-        calendarId="YOUR_CAL_ID"
-        apiKey="YOUR_API_KEY"
-        busyLabel="Do not disturb"
-        freeLabel="I'm free, talk to me!">
+        calendar-id="YOUR_CAL_ID"
+        api-key="YOUR_API_KEY"
+        busy-label="Do not disturb"
+        free-label="I'm free, talk to me!">
     </google-calendar-busy-now>
 
 */


### PR DESCRIPTION
Fixed the documentation for the `google-calendar-busy-now` element where the element attributes are written in camel case rather than having dashes in them.